### PR TITLE
Erix test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,21 @@
 VENV := .venv
 
 ifeq ($(OS),Windows_NT)
-    PYTHON     := $(VENV)/Scripts/python
-    PIP        := $(VENV)/Scripts/pip
-    PYTHON_CMD := python
-    VENV_STAMP := $(VENV)/Scripts/activate
+	SHELL		:= C:/Program Files/Git/usr/bin/sh.exe
+	export PATH	:= C:/Program Files/Git/usr/bin:$(PATH)
+	PYTHON		:= $(VENV)/Scripts/python
+	PYTHON_CMD	:= py -3.13
+	VENV_STAMP	:= $(VENV)/Scripts/activate
 else
-    PYTHON     := $(VENV)/bin/python3
-    PIP        := $(VENV)/bin/pip
-    PYTHON_CMD := python3
-    VENV_STAMP := $(VENV)/bin/activate
+	PYTHON		:= $(VENV)/bin/python3
+	PYTHON_CMD	:= python3
+	VENV_STAMP	:= $(VENV)/bin/activate
 endif
 
-VERSION := $(shell grep -m1 '__version__' instagiffer.py | awk -F'"' '{print $$2}')
+PIP			:= $(PYTHON) -m pip
+VERSION		:= $(shell grep -m1 '__version__' instagiffer.py | awk -F'"' '{print $$2}')
+DEPS_STAMP	:= build/.deps-stamp
+DIST_STAMP	:= build/.dist-stamp
 
 TEST_VIDEO_URLS := \
 	https://www.youtube.com/watch?v=aqz-KE-bpKQ \
@@ -58,15 +61,12 @@ clean:
 
 ifeq ($(shell uname -s),Darwin)
 
-APP_PATH     := dist/Instagiffer.app
-INSTALL_PATH := /Applications/Instagiffer.app
-MAGICK_OUT   := build/imagemagick/out
-FFMPEG_URL   := https://evermeet.cx/ffmpeg/getrelease/zip
-YTDLP_URL    := https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos
-YTDLP        := deps/mac/yt-dlp
-
-DEPS_STAMP := build/.deps-stamp
-DIST_STAMP := build/.dist-stamp
+APP_PATH		:= dist/Instagiffer.app
+INSTALL_PATH	:= /Applications/Instagiffer.app
+MAGICK_OUT		:= build/imagemagick/out
+FFMPEG_URL		:= https://evermeet.cx/ffmpeg/getrelease/zip
+YTDLP_URL		:= https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos
+YTDLP			:= deps/mac/yt-dlp
 
 deps: $(DEPS_STAMP)
 $(DEPS_STAMP): $(VENV_STAMP)
@@ -78,7 +78,9 @@ $(DEPS_STAMP): $(VENV_STAMP)
 	$(MAKE) -f imagemagick.mk
 	@mkdir -p deps/mac
 	@cp -R $(MAGICK_OUT)/* deps/mac/
+	@echo "Downloading ffmpeg from $(FFMPEG_URL) ..."
 	@[ -f deps/mac/ffmpeg ]   || (curl -fSL -o deps/mac/ffmpeg.zip "$(FFMPEG_URL)" && unzip -o deps/mac/ffmpeg.zip -d deps/mac/ && rm deps/mac/ffmpeg.zip && chmod +x deps/mac/ffmpeg)
+	@echo "Downloading yt-dlp from $(YTDLP_URL) ..."
 	@[ -f deps/mac/yt-dlp ]   || (curl -fSL -o deps/mac/yt-dlp "$(YTDLP_URL)" && chmod +x deps/mac/yt-dlp)
 	@[ -f deps/mac/gifsicle ] || cp "$$(which gifsicle)" deps/mac/gifsicle
 	@touch $@
@@ -86,7 +88,7 @@ $(DEPS_STAMP): $(VENV_STAMP)
 
 $(DIST_STAMP): $(VENV_STAMP) instagiffer.py main.py instagiffer.conf $(DEPS_STAMP)
 	@echo "Building Mac release with PyInstaller"
-	$(PYTHON) -m PyInstaller release/Instagiffer-mac.spec --distpath dist --workpath build/pyinstaller --noconfirm
+	$(PYTHON) -m PyInstaller --log-level WARN release/Instagiffer-mac.spec --distpath dist --workpath build/pyinstaller --noconfirm
 	codesign --force --deep --sign - $(APP_PATH)
 	@touch $@
 
@@ -114,36 +116,39 @@ install: $(DIST_STAMP)
 
 else ifeq ($(OS),Windows_NT)
 
-APP_PATH     := dist/Instagiffer
-INSTALL_PATH := C:/Program Files/Instagiffer/Instagiffer.exe
-ISCC         := $(or $(wildcard C:/Program Files (x86)/Inno Setup 6/ISCC.exe),$(LOCALAPPDATA)/Programs/Inno Setup 6/ISCC.exe)
-SEVENZIP     := C:/Program Files/7-Zip/7z.exe
-MAGICK_VER   := 7.1.2-15
-MAGICK_URL   := https://imagemagick.org/archive/binaries/ImageMagick-$(MAGICK_VER)-portable-Q16-x64.7z
-FFMPEG_URL   := https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip
-YTDLP_URL    := https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe
-YTDLP        := deps/win/yt-dlp.exe
-GIFSICLE_URL := https://eternallybored.org/misc/gifsicle/releases/gifsicle-1.95-win64.zip
-
-DEPS_STAMP    := build/.deps-stamp
-DIST_STAMP    := build/.dist-stamp
-INSTALL_STAMP := build/.install-stamp
+APP_PATH		:= dist/Instagiffer
+INSTALL_PATH	:= C:/Program Files/Instagiffer/Instagiffer.exe
+ISCC			:= ISCC.exe
+SEVENZIP		:= C:/Program Files/7-Zip/7z.exe
+MAGICK_BINS		:= https://imagemagick.org/archive/binaries/
+MAGICK_TYPE		:= -portable-Q8-x64.7z
+MAGICK_VER		:= $(shell curl -fsSL $(MAGICK_BINS) | grep -oP 'ImageMagick-\K[\d.]+-\d+(?=$(MAGICK_TYPE))' | sort -V | tail -1)
+MAGICK_URL		:= $(MAGICK_BINS)ImageMagick-$(MAGICK_VER)$(MAGICK_TYPE)
+FFMPEG_URL		:= https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip
+YTDLP_URL		:= https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe
+YTDLP			:= deps/win/yt-dlp.exe
+GIFSICLE_URL	:= https://eternallybored.org/misc/gifsicle/releases/gifsicle-1.95-win64.zip
+INSTALL_STAMP	:= build/.install-stamp
 
 deps: $(DEPS_STAMP)
 $(DEPS_STAMP): $(VENV_STAMP)
 	$(PIP) install -e ".[build-win,test-win]"
 	@mkdir -p deps/win build
+	@echo "Downloading ImageMagick from $(MAGICK_URL) ..."
 	@[ -f deps/win/magick.exe ] || ( \
 		curl -fSL -o build/magick-win.7z "$(MAGICK_URL)" && \
 		"$(SEVENZIP)" e build/magick-win.7z -odeps/win -y "magick.exe" && \
 		rm build/magick-win.7z )
+	@echo "Downloading ffmpeg from $(FFMPEG_URL) ..."
 	@[ -f deps/win/ffmpeg.exe ] || ( \
 		curl -fSL -o build/ffmpeg-win.zip "$(FFMPEG_URL)" && \
 		mkdir -p build/ffmpeg-tmp && \
 		unzip -o build/ffmpeg-win.zip -d build/ffmpeg-tmp && \
 		find build/ffmpeg-tmp -name ffmpeg.exe -exec cp {} deps/win/ \; && \
 		rm -rf build/ffmpeg-win.zip build/ffmpeg-tmp )
+	@echo "Downloading yt-dlp from $(YTDLP_URL) ..."
 	@[ -f deps/win/yt-dlp.exe ] || curl -fSL -o deps/win/yt-dlp.exe "$(YTDLP_URL)"
+	@echo "Downloading gifsicle from $(GIFSICLE_URL) ..."
 	@[ -f deps/win/gifsicle.exe ] || ( \
 		curl -fSL -o build/gifsicle-win.zip "$(GIFSICLE_URL)" && \
 		unzip -jo build/gifsicle-win.zip "*.exe" -d deps/win/ && \
@@ -152,21 +157,32 @@ $(DEPS_STAMP): $(VENV_STAMP)
 	@echo "Windows dependencies ready in deps/win/"
 
 $(DIST_STAMP): $(VENV_STAMP) instagiffer.py main.py instagiffer.conf $(DEPS_STAMP)
-	@echo "Building Windows release with PyInstaller"
-	$(PYTHON) -m PyInstaller release/Instagiffer-win.spec --distpath dist --workpath build/pyinstaller --noconfirm
+	@echo "Building Windows release with PyInstaller ..."
+	$(PYTHON) -m PyInstaller --log-level WARN release/Instagiffer-win.spec --distpath dist --workpath build/pyinstaller --noconfirm
 	@touch $@
 
 dist: $(DIST_STAMP)
 	@rm -f dist/instagiffer-$(VERSION)-setup.exe
-	"$(ISCC)" release/installer.iss //dMyAppVersion=$(VERSION)
+	@echo "Building Installer with Inno Setup ..."
+	@MSYS_NO_PATHCONV=1 "$(ISCC)" /Q release/installer.iss /dMyAppVersion=$(VERSION)
 	@SIZE=$$(stat -c%s "dist/instagiffer-$(VERSION)-setup.exe"); echo "Built dist/instagiffer-$(VERSION)-setup.exe ($$(( SIZE / 1048576 ))MB)"
 
 install: $(INSTALL_STAMP)
 $(INSTALL_STAMP): $(DIST_STAMP) release/installer.iss
 	@rm -f dist/instagiffer-$(VERSION)-setup.exe
-	"$(ISCC)" release/installer.iss //dMyAppVersion=$(VERSION)
-	MSYS_NO_PATHCONV=1 dist/instagiffer-$(VERSION)-setup.exe /VERYSILENT /SUPPRESSMSGBOXES
+	@echo "Building Installer with Inno Setup ..."
+	@MSYS_NO_PATHCONV=1 "$(ISCC)" /Q release/installer.iss /dMyAppVersion=$(VERSION)
+	@echo "Calling Installer ..."
+	@MSYS_NO_PATHCONV=1 dist/instagiffer-$(VERSION)-setup.exe /VERYSILENT /SUPPRESSMSGBOXES
 	@touch $@
 	@echo "Installed to $(INSTALL_PATH)"
 
 endif
+
+redist:
+	@rm -f $(DIST_STAMP)
+	$(MAKE) dist
+
+redeps:
+	@rm -f $(DEPS_STAMP)
+	$(MAKE) deps

--- a/install-devtools.ps1
+++ b/install-devtools.ps1
@@ -16,36 +16,72 @@ if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
     exit 1
 }
 
+$PythonVersion = "3.13"
 $packages = @(
-    @{ Id = "Python.Python.3.13";   Name = "Python 3.13"    },  # any 3.10+ works; skip if already installed
-    @{ Id = "Git.Git";              Name = "Git for Windows" },  # needed for Git Bash, which runs make
+    # any Python 3.10+ works; skip if already installed:
+    @{ Id = "Python.Python.$PythonVersion";   Name = "Python $PythonVersion"; Override = "Include_tcltk=1"},
+    # needed for Git Bash, which runs make:
+    @{ Id = "Git.Git";              Name = "Git for Windows" },
     @{ Id = "GnuWin32.Make";        Name = "GNU Make"        },
-    @{ Id = "7zip.7zip";            Name = "7-Zip"           },  # needed to extract ImageMagick portable archive
-    @{ Id = "JRSoftware.InnoSetup"; Name = "Inno Setup 6"   }
+    # needed to extract ImageMagick portable archive:
+    @{ Id = "7zip.7zip";            Name = "7-Zip"           },
+    @{ Id = "JRSoftware.InnoSetup"; Name = "Inno Setup 6"    }
 )
 
 $alreadyInstalled = -1978335189
 foreach ($pkg in $packages) {
+    if ($pkg.Id -eq "Python.Python.$PythonVersion") {
+        $hasPython = (Get-Command "py" -ErrorAction SilentlyContinue) -and (& py -$PythonVersion --version 2>$null)
+        & py -$PythonVersion -c "import tkinter" 2>$null
+        $hasTk = $hasPython -and ($LASTEXITCODE -eq 0)
+
+        if ($hasTk) {
+            Write-Host "Python $PythonVersion with tkinter already present, skipping." -ForegroundColor Green
+            continue
+        } elseif ($hasPython) {
+            Write-Host "Python $PythonVersion found but tkinter missing, modifying installation..." -ForegroundColor Yellow
+            winget install --id $pkg.Id --source winget --accept-source-agreements --accept-package-agreements --force --override "Include_tcltk=1"
+        } else {
+            Write-Host "Installing Python $PythonVersion with tkinter..." -ForegroundColor Yellow
+            winget install --id $pkg.Id --source winget --silent --accept-source-agreements --accept-package-agreements
+        }
+        continue
+    }
+
     Write-Host "Installing $($pkg.Name)..." -ForegroundColor Yellow
-    winget install --id $pkg.Id --source winget --silent --accept-source-agreements --accept-package-agreements
+    winget install --id $pkg.Id --source winget --silent --accept-source-agreements --accept-package-agreements$override
     if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne $alreadyInstalled) {
         Write-Warning "$($pkg.Name) install returned exit code $LASTEXITCODE - you may need to install it manually."
     }
 }
 
-# Add GNU Make to the current user PATH so Git Bash can find it
-$makePath = "C:\Program Files (x86)\GnuWin32\bin"
-if (Test-Path $makePath) {
-    $current = [Environment]::GetEnvironmentVariable("PATH", "User")
-    if ($current -notlike "*GnuWin32*") {
-        $newPath = if ($current) { "$current;$makePath" } else { $makePath }
-        [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
-        Write-Host "Added GNU Make to user PATH." -ForegroundColor Green
+function Add-ToUserPath {
+    param(
+        [string]$Path,
+        [string]$Name
+    )
+    if (Test-Path $Path) {
+        $current = [Environment]::GetEnvironmentVariable("PATH", "User")
+        if ($current -notlike "*$Name*") {
+            $newPath = if ($current) { "$current;$Path" } else { $Path }
+            [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+            Write-Host "Added $Name to user PATH." -ForegroundColor Green
+        } else {
+            Write-Host "$Name already on PATH." -ForegroundColor Green
+        }
     } else {
-        Write-Host "GNU Make already on PATH." -ForegroundColor Green
+        Write-Warning "$Name not found at $Path - install may have failed. Add it to PATH manually if needed."
     }
-} else {
-    Write-Warning "GNU Make not found at $makePath - install may have failed. Add it to PATH manually if needed."
 }
+
+# Add GNU Make to the current user PATH so Git Bash can find it
+Add-ToUserPath "${env:ProgramFiles(x86)}\GnuWin32\bin" "GNU Make"
+
+# Add Inno Setup to current user PATH so make can find it
+$isccPath = "${env:ProgramFiles(x86)}\Inno Setup 6"
+if (-not (Test-Path $isccPath)) {
+    $isccPath = "${env:LOCALAPPDATA}\Programs\Inno Setup 6"
+}
+Add-ToUserPath $isccPath "Inno Setup"
 
 Write-Host "Done." -ForegroundColor Green

--- a/install-devtools.ps1
+++ b/install-devtools.ps1
@@ -22,7 +22,7 @@ $packages = @(
     @{ Id = "Python.Python.$PythonVersion";   Name = "Python $PythonVersion"; Override = "Include_tcltk=1"},
     # needed for Git Bash, which runs make:
     @{ Id = "Git.Git";              Name = "Git for Windows" },
-    @{ Id = "GnuWin32.Make";        Name = "GNU Make"        },
+    @{ Id = "ezwinports.make";      Name = "GNU Make"        },
     # needed to extract ImageMagick portable archive:
     @{ Id = "7zip.7zip";            Name = "7-Zip"           },
     @{ Id = "JRSoftware.InnoSetup"; Name = "Inno Setup 6"    }
@@ -65,17 +65,14 @@ function Add-ToUserPath {
         if ($current -notlike "*$Name*") {
             $newPath = if ($current) { "$current;$Path" } else { $Path }
             [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
-            Write-Host "Added $Name to user PATH." -ForegroundColor Green
+            Write-Host "Added $Name to user PATH!" -ForegroundColor Green
         } else {
-            Write-Host "$Name already on PATH." -ForegroundColor Green
+            Write-Host "$Name already on PATH!" -ForegroundColor Green
         }
     } else {
         Write-Warning "$Name not found at $Path - install may have failed. Add it to PATH manually if needed."
     }
 }
-
-# Add GNU Make to the current user PATH so Git Bash can find it
-Add-ToUserPath "${env:ProgramFiles(x86)}\GnuWin32\bin" "GNU Make"
 
 # Add Inno Setup to current user PATH so make can find it
 $isccPath = "${env:ProgramFiles(x86)}\Inno Setup 6"
@@ -83,5 +80,18 @@ if (-not (Test-Path $isccPath)) {
     $isccPath = "${env:LOCALAPPDATA}\Programs\Inno Setup 6"
 }
 Add-ToUserPath $isccPath "Inno Setup"
+
+$gitSh = (Get-Command "git" -ErrorAction SilentlyContinue).Source -replace "cmd\\git.exe", "usr\bin\sh.exe"
+if ($gitSh -and (Test-Path $gitSh)) {
+    $gitShForward = $gitSh -replace "\\", "/"
+    if ($gitShForward -ne "C:/Program Files/Git/usr/bin/sh.exe") {
+        Write-Warning "Git is installed at a non-default location: $gitShForward"
+        Write-Warning "Update SHELL in `Makefile` to: $gitShForward"
+    } else {
+        Write-Host "Git sh.exe found at expected location!" -ForegroundColor Green
+    }
+} else {
+    Write-Warning "Could not detect Git sh.exe location!"
+}
 
 Write-Host "Done." -ForegroundColor Green


### PR DESCRIPTION
Hey @exhale-io ! I tried it out on my machine and ran into a few things.
Highlights:
### install-devtools.ps1:
- [x] my Python 3.13 didn't have `tkinter`. I made sure the that's now installed alongside or modified to be available
- [x] outdated `GnuWin32.Make` was giving me problems, replaced it with `ezwinports.make` which has `4.4.x` available
- [x] added `$PythonVersion` to reduce repetition
- [x] Inno Setup path didn't work for me in Makefile so I ensured it's added to PATH here
### Makefile
- [x] the hardcoded ImageMagick version was already gone from their download page. A grep from the page to get the latest version was added to solve this
  - [x] also made the ImageMagick URL-parts reusable and turned it to Q8 which should be enough for gifs
- [x] make commands didn't run nicely from VS Code Terminal (I know you put to use bash in the docs but I was looking into solving it) adding `SHELL` and `PATH` export did the trick!
- [x] added `redist` and `redeps` targets for rebuilding without manually deleting stamps
- [x] reduced some log spam from PyInstaller and Inno Setup
- [x] added download progress echoes so failures are easier to diagnose