### PR TITLE
#11 fix bug reporting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+install-devtools.sh text eol=lf
+*.sh text eol=lf

--- a/Makefile
+++ b/Makefile
@@ -228,11 +228,11 @@ INSTALL_PATH	:= /opt/instagiffer
 # to avoid NTFS permission issues with dpkg-deb.
 IN_MNT := $(filter /mnt/%,$(CURDIR))
 ifdef IN_MNT
+	DIST_ARTIFACT	:= /tmp/instagiffer_$(VERSION)_amd64.deb
+	DEB_ROOT		:= /tmp/deb_pkg
+else
 	DIST_ARTIFACT	:= dist/instagiffer_$(VERSION)_amd64.deb
 	DEB_ROOT		:= dist/deb_pkg
-else
-	DIST_ARTIFACT	:= /tmp/instagiffer_$(VERSION)_amd64.deb
-  DEB_ROOT		:= /tmp/deb_pkg
 endif
 DEB_OUT			:= $(DIST_ARTIFACT)
 DEB_COMPRESS	?= gzip # override with: make dist DEB_COMPRESS=xz
@@ -266,7 +266,7 @@ $(DIST_STAMP): $(VENV_STAMP) instagiffer.py main.py instagiffer.conf $(DEPS_STAM
 	@touch $@
 
 dist: $(DIST_STAMP)
-	@echo "  Building package tree ..."
+	@echo "  Building package tree in $(DEB_ROOT) ..."
 	@rm -rf $(DEB_ROOT)
 	@mkdir -p $(DEB_ROOT)/DEBIAN
 	@mkdir -p $(DEB_ROOT)$(INSTALL_PATH)

--- a/instagiffer.py
+++ b/instagiffer.py
@@ -99,6 +99,15 @@ def ImAPC():
     return sys.platform == "win32"
 
 
+def ImAWSL():
+    try:
+        with open("/proc/version") as file_object:
+            version = file_object.read().lower()
+            return "microsoft" in version and "wsl" in version
+    except OSError:
+        return False
+
+
 def GetDisplayScaleFactor():
     """Return the physical-to-logical pixel ratio on Windows (e.g. 1.25 for 125% scaling).
 
@@ -129,18 +138,32 @@ def GetDisplayScaleFactor():
     return scale if scale > 1.0 else 1.0
 
 
-def OpenFileWithDefaultApp(fileName):
+def OpenFileWithDefaultApp(fileName: str) -> None:
     """Open a file in the application associated with this file extension"""
-    if not ImAPC():
-        subprocess.Popen(["open", fileName])
-    else:
-        try:
-            os.startfile(fileName)
-        except OSError:
-            tkMessageBox.showinfo(
-                "Unable to open!",
-                "I wasn't allowed to open '" + fileName + "'. You will need to perform this task manually.",
-            )
+    try:
+        if ImAWSL():
+            subprocess.Popen(f'powershell.exe -c "Start-Process \'{fileName}\'"', shell=True)
+
+        elif fileName.startswith('http'):
+            import webbrowser
+
+            webbrowser.open(fileName)
+        else:
+            if ImAMac():
+                subprocess.Popen(["open", fileName])
+            elif ImAPC():
+                os.startfile(fileName)
+            else:
+                subprocess.Popen(["xdg-open", fileName])
+
+    except OSError:
+        report = traceback.format_exc().strip()
+        print(report)
+        tkMessageBox.showinfo(
+            "Unable to open!",
+            f"I wasn't allowed to open '{fileName}'. You will need to perform this task manually!\n"
+            f"{report}"
+        )
 
 
 def GetFileExtension(filename):
@@ -2867,7 +2890,7 @@ class GifApp:
         self.helpMenu.add_command(label="Check For Updates", underline=0, command=self.CheckForUpdates)
         self.helpMenu.add_command(label="Frequently Asked Questions", underline=0, command=self.OpenFAQ)
         self.helpMenu.add_separator()
-        self.helpMenu.add_command(label="Generate Bug Report", underline=0, command=self.ViewLog)
+        self.helpMenu.add_command(label="Generate Bug Report", underline=0, command=self.GenerateBugReport)
 
         # Top-level
         self.menubar.add_cascade(label="File", underline=0, menu=self.fileMenu)
@@ -4329,22 +4352,24 @@ class GifApp:
             "You are running Instagiffer " + __version__ + "!\nhttps://github.com/ex-hale/instagiffer",
         )
 
-    def ViewLog(self):
-        logPath = GetLogPath()
-
+    def GenerateBugReport(self):
+        import urllib.parse
         try:
-            numLines = sum(1 for line in open(logPath))
-        except FileNotFoundError:
-            numLines = 0
+            with open(GetLogPath()) as file_object:
+                # only last 3000 chars to stay under URL limits
+                log_content = file_object.read()[-3000:]
+        except OSError:
+            log_content = "(could not read log)"
 
-        if numLines <= 7:
-            tkMessageBox.showinfo(
-                "Bug Report",
-                "It looks like the bug report is currently empty. Please try to reproduce the bug first, and then generate the report.",
-            )
-            return
+        title = "Bug report"
+        body = f"**Describe the bug**\n\n\n**Log**\n```\n{log_content}\n```"
 
-        OpenFileWithDefaultApp(logPath)
+        url = "https://github.com/ex-hale/instagiffer/issues/new?" + urllib.parse.urlencode({
+            "title": title,
+            "body": body,
+        })
+        print(f'{url = }')
+        OpenFileWithDefaultApp(url)
 
     def OpenFAQ(self):
         OpenFileWithDefaultApp(__faqUrl__)

--- a/instagiffer.py
+++ b/instagiffer.py
@@ -144,7 +144,7 @@ def OpenFileWithDefaultApp(fileName: str) -> None:
         if ImAWSL():
             subprocess.Popen(f'powershell.exe -c "Start-Process \'{fileName}\'"', shell=True)
 
-        elif fileName.startswith('http'):
+        elif IsUrl(fileName):
             import webbrowser
 
             webbrowser.open(fileName)

--- a/instagiffer.py
+++ b/instagiffer.py
@@ -158,11 +158,10 @@ def OpenFileWithDefaultApp(fileName: str) -> None:
 
     except OSError:
         report = traceback.format_exc().strip()
-        print(report)
+        logging.error(report)
         tkMessageBox.showinfo(
             "Unable to open!",
-            f"I wasn't allowed to open '{fileName}'. You will need to perform this task manually!\n"
-            f"{report}"
+            f"I wasn't allowed to open '{fileName}'. You will need to perform this task manually!"
         )
 
 
@@ -4368,7 +4367,6 @@ class GifApp:
             "title": title,
             "body": body,
         })
-        print(f'{url = }')
         OpenFileWithDefaultApp(url)
 
     def OpenFAQ(self):


### PR DESCRIPTION
Ooof I tried so many things to pipe these huge bug-reporting URLs through to Windows... explorer.exe, cmd.exe ... powershell.exe was kinda working in the end but still needed `shell=True` to stop it messing with escaping the quotation. Well. This is a WSL thing only anyway.
I also made the `ViewLog` method which was only used from the "Generate Bug Report" menu a dedicated `GenerateBugReport` method :D It mangles the log contents into a dedicated GitHub-new-issue URL.
The `OpenFileWithDefaultApp` function now handles calls to `http....` with the builtin `webbrowser` package (if not WSL, which would still cause #11)
Cheers! Good night!
ëRiC